### PR TITLE
Fix local installation

### DIFF
--- a/qt/CMakeLists.txt
+++ b/qt/CMakeLists.txt
@@ -67,7 +67,7 @@ if (BUILD_QT_UI)
 
   if (NOT ${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
     install(PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/android-file-transfer DESTINATION bin)
-    install (FILES ${CMAKE_CURRENT_SOURCE_DIR}/android-file-transfer.desktop DESTINATION /usr/share/applications)
+    install (FILES ${CMAKE_CURRENT_SOURCE_DIR}/android-file-transfer.desktop DESTINATION share/applications)
     install (FILES ${CMAKE_CURRENT_SOURCE_DIR}/android-file-transfer.png DESTINATION share/icons/hicolor/128x128/apps)
   endif()
 endif()


### PR DESCRIPTION
Installing to /usr/.. overrides the user supplied CMAKE_INSTALL_PREFIX, which breaks installing to a local dir as non-root.