### PR TITLE
Fix build on FreeBSD

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,11 +38,14 @@ include(CheckIncludeFiles)
 
 find_package ( Threads )
 
-if (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
-	option(BUILD_FUSE "Build fuse mount helper" ON)
+# Don't mistake osx for unix
+if(UNIX AND NOT APPLE)
+  set(UNIX_SYS ON)
 else()
-	set(BUILD_FUSE OFF)
+  set(UNIX_SYS OFF)
 endif()
+
+option(BUILD_FUSE "Build fuse mount helper" ${UNIX_SYS})
 
 if (BUILD_FUSE)
 	pkg_check_modules ( FUSE fuse )

--- a/cli/CMakeLists.txt
+++ b/cli/CMakeLists.txt
@@ -17,4 +17,4 @@ endif()
 
 add_executable(aft-mtp-cli ${CLI_SOURCES})
 target_link_libraries(aft-mtp-cli ${MTP_LIBRARIES} ${CLI_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
-install(PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/aft-mtp-cli DESTINATION bin)
+install(TARGETS aft-mtp-cli RUNTIME DESTINATION bin)

--- a/fuse/CMakeLists.txt
+++ b/fuse/CMakeLists.txt
@@ -1,4 +1,4 @@
 add_executable(aft-mtp-mount fuse_ll.cpp)
 
 target_link_libraries(aft-mtp-mount ${MTP_LIBRARIES} ${FUSE_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
-install(PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/aft-mtp-mount DESTINATION bin)
+install(TARGETS aft-mtp-mount RUNTIME DESTINATION bin)

--- a/fuse/fuse_ll.cpp
+++ b/fuse/fuse_ll.cpp
@@ -42,7 +42,12 @@ namespace
 		static std::string GetErrorMessage(int returnCode)
 		{
 			char buf[1024];
+#ifdef _GNU_SOURCE
 			std::string text(strerror_r(returnCode, buf, sizeof(buf)));
+#else
+			int r = strerror_r(returnCode, buf, sizeof(buf));
+			std::string text(r == 0? buf: "strerror_r() failed");
+#endif
 			return text;
 		}
 	};

--- a/mtp/Demangle.h
+++ b/mtp/Demangle.h
@@ -21,6 +21,7 @@
 #define AFS_MTP_DEMANGLE_H
 
 #include <cxxabi.h>
+#include <stdlib.h>
 
 namespace mtp
 {

--- a/mtp/backend/libusb/usb/Exception.cpp
+++ b/mtp/backend/libusb/usb/Exception.cpp
@@ -19,6 +19,7 @@
 
 #include <usb/Exception.h>
 #include <libusb.h>
+#include <string>
 
 namespace mtp { namespace usb
 {

--- a/mtp/backend/posix/Exception.cpp
+++ b/mtp/backend/posix/Exception.cpp
@@ -35,11 +35,11 @@ namespace mtp { namespace posix
 	std::string Exception::GetErrorMessage(int returnCode)
 	{
 		char buf[1024];
-#if defined(__APPLE__) || ((_POSIX_C_SOURCE >= 200112L || _XOPEN_SOURCE >= 600) && ! _GNU_SOURCE)
+#ifdef _GNU_SOURCE
+		std::string text(strerror_r(returnCode, buf, sizeof(buf)));
+#else
 		int r = strerror_r(returnCode, buf, sizeof(buf));
 		std::string text(r == 0? buf: "strerror_r() failed");
-#else
-		std::string text(strerror_r(returnCode, buf, sizeof(buf)));
 #endif
 		return text;
 	}

--- a/qt/CMakeLists.txt
+++ b/qt/CMakeLists.txt
@@ -66,7 +66,7 @@ if (BUILD_QT_UI)
 	target_link_libraries(android-file-transfer ${EXTRA_QT_LINK} ${MTP_LIBRARIES})
 
   if (NOT ${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
-    install(PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/android-file-transfer DESTINATION bin)
+    install(TARGETS android-file-transfer RUNTIME DESTINATION bin)
     install (FILES ${CMAKE_CURRENT_SOURCE_DIR}/android-file-transfer.desktop DESTINATION share/applications)
     install (FILES ${CMAKE_CURRENT_SOURCE_DIR}/android-file-transfer.png DESTINATION share/icons/hicolor/128x128/apps)
   endif()


### PR DESCRIPTION
Part of my [sysutils/android-file-transfer](https://www.freshports.org/sysutils/android-file-transfer) port. Build logs for 40640fb in a few days:
- [9.3 i386](http://beefy1.nyi.freebsd.org/data/93i386-default/latest-per-pkg/android-file-transfer-3.0.10.log), [9.3 amd64](http://beefy2.nyi.freebsd.org/data/93amd64-default/latest-per-pkg/android-file-transfer-3.0.10.log) (gcc/libstdc++ 4.8)
- [10.1 i386](http://beefy5.nyi.freebsd.org/data/101i386-default/latest-per-pkg/android-file-transfer-3.0.10.log), [10.1 amd64](http://beefy6.nyi.freebsd.org/data/101amd64-default/latest-per-pkg/android-file-transfer-3.0.10.log) (clang/libc++ 3.4)
- [11.0 amd64](http://beefy9.nyi.freebsd.org/data/110amd64-default/latest-per-pkg/android-file-transfer-3.0.10.log), [11.0 i386](http://beefy10.nyi.freebsd.org/data/110i386-default/latest-per-pkg/android-file-transfer-3.0.10.log) (clang/libc++ 3.8)
- [12.0 i386](http://beefy3.nyi.freebsd.org/data/head-i386-default/latest-per-pkg/android-file-transfer-3.0.10.log), [12.0 amd64](http://beefy4.nyi.freebsd.org/data/head-amd64-default/latest-per-pkg/android-file-transfer-3.0.10.log) (clang/libc++ 3.8 or 3.9 [soon](https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=212343))
- [dragonfly](http://muscles.dragonflybsd.org/bulk/latest-per-pkg/android-file-transfer/3.0.10/bleeding-edge-potential.log) (gcc/libstdc++ 5.3)
