### PR TITLE
Unbreak build on FreeBSD after fuse/ code split

### DIFF
--- a/fuse/Exception.h
+++ b/fuse/Exception.h
@@ -22,6 +22,7 @@
 
 #include <stdexcept>
 #include <string>
+#include <errno.h>
 #include <string.h>
 
 namespace mtp { namespace fuse

--- a/fuse/fuse_ll.cpp
+++ b/fuse/fuse_ll.cpp
@@ -30,8 +30,10 @@
 
 #include <mtp/log.h>
 
+#include <map>
 #include <set>
 #include <vector>
+#include <stdio.h>
 
 #include <fuse_lowlevel.h>
 


### PR DESCRIPTION
```c++
In file included from fuse/fuse_ll.cpp:20:
./fuse/Exception.h:33:97: error:
      use of undeclared identifier 'errno'
  ...std::string &what) throw() : std::runtime_error(what + ": " + GetErrorMessage(errno)) { }
                                                                                   ^
fuse/fuse_ll.cpp:51:16: error:
      no type named 'map' in namespace 'std'
                typedef std::map<std::string, FuseId> ChildrenObjects;
                        ~~~~~^
fuse/fuse_ll.cpp: In member function 'void {anonymous}::FuseWrapper::PopulateStorages()':
fuse/fuse_ll.cpp:422:56: error: 'snprintf' was not declared in this scope
      snprintf(buf, sizeof(buf), "sdcard%u", (unsigned)i);
                                                        ^
fuse/fuse_ll.cpp: In function 'int main(int, char**)':
fuse/fuse_ll.cpp:807:29: error: 'perror' was not declared in this scope
      perror("fuse_daemonize");
```