### PR TITLE
Add missing #include <functional>s

### DIFF
--- a/fuse/fuse_ll.cpp
+++ b/fuse/fuse_ll.cpp
@@ -33,6 +33,7 @@
 #include <map>
 #include <set>
 #include <vector>
+#include <functional>
 #include <stdio.h>
 
 #include <fuse_lowlevel.h>

--- a/mtp/backend/linux/usb/Device.h
+++ b/mtp/backend/linux/usb/Device.h
@@ -28,6 +28,7 @@
 #include <FileHandler.h>
 #include <map>
 #include <queue>
+#include <functional>
 
 namespace mtp { namespace usb
 {

--- a/mtp/function_invoker.h
+++ b/mtp/function_invoker.h
@@ -20,6 +20,8 @@
 #ifndef MTP_FUNCTION_INVOKER_H
 #define MTP_FUNCTION_INVOKER_H
 
+#include <functional>
+
 namespace mtp
 {
 

--- a/mtp/make_function.h
+++ b/mtp/make_function.h
@@ -20,6 +20,8 @@
 #ifndef AFT_CLI_MAKE_FUNCTION_H
 #define AFT_CLI_MAKE_FUNCTION_H
 
+#include <functional>
+
 namespace mtp
 {
 


### PR DESCRIPTION
Fix compilation with GCC 7. The <functional> header is no longer
included by other standard library headers. Include it explicitly where
we use std::function.

See also: https://gcc.gnu.org/gcc-7/porting_to.html#header-dep-changes