### PR TITLE
fix an osxfuse timeout problem

### DIFF
--- a/fuse/fuse_ll.cpp
+++ b/fuse/fuse_ll.cpp
@@ -589,6 +589,7 @@ namespace
 		{
 			mtp::scoped_mutex_lock l(_mutex);
 			ReleaseTransaction(ino);
+			FUSE_CALL(fuse_reply_err(req, 0));
 		}
 
 		void Rename(fuse_req_t req, FuseId parent, const char *name, FuseId newparent, const char *newname)


### PR DESCRIPTION
I managed to debug the issue using the `-d` flag to `aft-mtp-mount`. This clarified where a simple read would never finish (~3 minutes) hanged (after `    Release nnnnn` debug output).

I then built and tested this custom version on my Mac ("High Sierra" w/ an Android Nougat Phone connected) using the following commands:

    umount /Volumes/MTP && (mkdir -p $PWD-build; cd $_ && cmake $OLDPWD -DBUILD_FUSE=on && make; cd fuse && eval $(cat CMakeFiles/aft-mtp-mount.dir/link.txt; echo -L/opt/local/lib))
    sudo bash -c 'mkdir -p /Volumes/MTP && chown $SUDO_USER: $_' && $PWD-build/fuse/aft-mtp-mount /Volumes/MTP && cat /Volumes/MTP/Internal*/customized-capability.xml

`aft-mtp-mount` works fine now, while before the change directory listings worked, but not reads. (Writes not tested before, getting "Operation not permitted" error right now....)

references:
https://manpages.debian.org/testing/manpages/fuse.4.en.html
https://github.com/osxfuse/osxfuse/issues/208#issuecomment-108114928
http://fuse.996288.n3.nabble.com/PATCH-0-5-fuse-handle-release-synchronously-v4-td12551.html