### PR TITLE
Fix unit usage

### DIFF
--- a/qt/android-file-transfer.qrc
+++ b/qt/android-file-transfer.qrc
@@ -2,7 +2,7 @@
     <qresource prefix="/">
         <file>android-file-transfer.png</file>
         <file>translations/android-file-transfer-linux_ru.qm</file>
-		<file>translations/android-file-transfer-linux_cs.qm</file>
+        <file>translations/android-file-transfer-linux_cs.qm</file>
         <file>icons/dark/folder-new.svg</file>
         <file>icons/dark/go-next.svg</file>
         <file>icons/dark/go-previous.svg</file>

--- a/qt/progressdialog.cpp
+++ b/qt/progressdialog.cpp
@@ -97,15 +97,15 @@ void ProgressDialog::setValue(float current)
 
 void ProgressDialog::setSpeed(qint64 speed)
 {
-	static constexpr double Kb = 1000;
-	static constexpr double Mb = 1000 * Kb; //haha
-	static constexpr double Gb = 1000 * Mb;
-	if (speed < 2 * Mb)
-		ui->speedLabel->setText(tr("Speed: %1 Kb/s").arg(speed / Kb, 0, 'f', 1));
-	else if (speed < 2 * Gb)
-		ui->speedLabel->setText(tr("Speed: %1 Mb/s").arg(speed / Mb, 0, 'f', 1));
+	static constexpr double kB = 1000;
+	static constexpr double MB = 1000 * kB; // k, M, G are metric prefixes
+	static constexpr double GB = 1000 * MB; // 1024 is for binary prefixes
+	if (speed < 2 * MB)
+		ui->speedLabel->setText(tr("Speed: %1 kB/s").arg(speed / kB, 0, 'f', 1));
+	else if (speed < 2 * GB)
+		ui->speedLabel->setText(tr("Speed: %1 MB/s").arg(speed / MB, 0, 'f', 1));
 	else
-		ui->speedLabel->setText(tr("Speed: %1 Gb/s").arg(speed / Gb, 0, 'f', 1));
+		ui->speedLabel->setText(tr("Speed: %1 GB/s").arg(speed / GB, 0, 'f', 1));
 }
 
 void ProgressDialog::setFilename(const QString &filename)

--- a/qt/translations/android-file-transfer-linux_cs.ts
+++ b/qt/translations/android-file-transfer-linux_cs.ts
@@ -465,18 +465,18 @@ Prosím odemčete jej a zmáčknětě Zkust znovu pro pokračování nebo Zruši
     </message>
     <message>
         <location filename="../progressdialog.cpp" line="104"/>
-        <source>Speed: %1 Kb/s</source>
-        <translation>Rychlost: %1 Kb/s</translation>
+        <source>Speed: %1 kB/s</source>
+        <translation>Rychlost: %1 kB/s</translation>
     </message>
     <message>
         <location filename="../progressdialog.cpp" line="106"/>
-        <source>Speed: %1 Mb/s</source>
-        <translation>Rychlost: %1 Mb/s</translation>
+        <source>Speed: %1 MB/s</source>
+        <translation>Rychlost: %1 MB/s</translation>
     </message>
     <message>
         <location filename="../progressdialog.cpp" line="108"/>
-        <source>Speed: %1 Gb/s</source>
-        <translation>Rychlost: %1 Gb/s</translation>
+        <source>Speed: %1 GB/s</source>
+        <translation>Rychlost: %1 GB/s</translation>
     </message>
 </context>
 <context>

--- a/qt/translations/android-file-transfer-linux_it.ts
+++ b/qt/translations/android-file-transfer-linux_it.ts
@@ -240,18 +240,18 @@ Si prega di sbloccare e premere Ritenta per continuare o Interrompere per uscire
     </message>
     <message>
         <location filename="../progressdialog.cpp" line="95"/>
-        <source> Kb/s</source>
-        <translation> Kb/s</translation>
+        <source> kB/s</source>
+        <translation> kB/s</translation>
     </message>
     <message>
         <location filename="../progressdialog.cpp" line="97"/>
-        <source> Mb/s</source>
-        <translation> Mb/s</translation>
+        <source> MB/s</source>
+        <translation> MB/s</translation>
     </message>
     <message>
         <location filename="../progressdialog.cpp" line="99"/>
-        <source> Gb/s</source>
-        <translation> Gb/s</translation>
+        <source> GB/s</source>
+        <translation> GB/s</translation>
     </message>
 </context>
 <context>

--- a/qt/translations/android-file-transfer-linux_ru.ts
+++ b/qt/translations/android-file-transfer-linux_ru.ts
@@ -477,16 +477,16 @@ Please unlock and press Retry to continue or Abort to exit.</source>
         <translation type="vanished">Скорость:</translation>
     </message>
     <message>
-        <source> Kb/s</source>
-        <translation type="vanished">Кб/с</translation>
+        <source> kB/s</source>
+        <translation type="vanished">кБ/с</translation>
     </message>
     <message>
-        <source> Mb/s</source>
-        <translation type="vanished">Мб/с</translation>
+        <source> MB/s</source>
+        <translation type="vanished">МБ/с</translation>
     </message>
     <message>
-        <source> Gb/s</source>
-        <translation type="vanished">Гб/с</translation>
+        <source> GB/s</source>
+        <translation type="vanished">ГБ/с</translation>
     </message>
     <message>
         <location filename="../progressdialog.cpp" line="104"/>


### PR DESCRIPTION
Resolve #242 
By the way, the metric prefix for kilo is `k`, not `K`, which equal to 1000. If you want to use 1024 base, you should use [binary prefixes](https://en.wikipedia.org/wiki/Binary_prefix) instead.