### PR TITLE
solve the bug that the process did not respond when renaming

### DIFF
--- a/mtp/ptp/Session.cpp
+++ b/mtp/ptp/Session.cpp
@@ -126,8 +126,7 @@ namespace mtp
 		{
 			DataRequest req(code, transaction.Id);
 			Container container(req, inputStream);
-			_packeter.Write(std::make_shared<ByteArrayObjectInputStream>(container.Data), timeout);
-			_packeter.Write(inputStream, timeout);
+            _packeter.Write(std::make_shared<JoinedObjectInputStream>(std::make_shared<ByteArrayObjectInputStream>(container.Data), inputStream), timeout);
 		}
 		return Get(transaction.Id, response);
 	}


### PR DESCRIPTION
At present, there is a problem in QT GUI renaming. I find that the problem is caused by optimizing the code before, so I think it should be changed back to the original state, commit is 070042d205849641027997b6959c587bbb2bd890 in last time.