### PR TITLE
Fix DST handling in DateTime conversion

### DIFF
--- a/mtp/ptp/ObjectFormat.cpp
+++ b/mtp/ptp/ObjectFormat.cpp
@@ -175,6 +175,7 @@ namespace mtp
 	time_t ConvertDateTime(const std::string &timespec)
 	{
 		struct tm time = {};
+		time.tm_isdst = -1;
 		char *end = strptime(timespec.c_str(), "%Y%m%dT%H%M%S", &time);
 		if (!end)
 			return 0;


### PR DESCRIPTION
The field tm_isdst needs to be set to a negative value for mktime to apply the local daylight saving time rules.

Obviously, times are still going to be wrong when the time zones of the devices don't match. But as long as they do, this should actually result in correct times, except for cases where there is ambiguity due to DST (but that is unfixable as long as the device only reports local times without timezone offset).