### PR TITLE
Fix wrong resetDevice value.

### DIFF
--- a/fuse/fuse_ll.cpp
+++ b/fuse/fuse_ll.cpp
@@ -875,7 +875,7 @@ int main(int argc, char **argv)
 	for(int i = 1; i < argc; ++i)
 	{
 		if (strcmp(argv[i], "-R") == 0)
-			resetDevice = false;
+			resetDevice = true;
 		else if (strcmp(argv[i], "-C") == 0)
 			claimInterface = false;
 		else if (strcmp(argv[i], "-d") == 0 || strcmp(argv[i], "-odebug") == 0)


### PR DESCRIPTION
I see the in fuse_ll.cpp main() the resetDevice init as  false; but after that if user pass -R, it should be true, and do reset operations.