### PR TITLE
Fix build with GCC 13

### DIFF
--- a/mtp/types.h
+++ b/mtp/types.h
@@ -27,6 +27,7 @@
 #include <memory>
 #include <mutex>
 #include <exception>
+#include <stdexcept>
 #include <string>
 
 namespace mtp


### PR DESCRIPTION
GCC 13 (as usual for new compiler releases) shuffles around some internal includes so some are no longer transitively included.

See https://gnu.org/software/gcc/gcc-13/porting_to.html.

Bug: https://bugs.gentoo.org/894788