### PR TITLE
Proposal to add get-id command to cli.

### DIFF
--- a/cli/Session.cpp
+++ b/cli/Session.cpp
@@ -130,6 +130,10 @@ namespace cli
 			make_function([this](const Path &path) -> void { Get(path); }));
 		AddCommand("get", "<file> <dst> downloads file to <dst>",
 			make_function([this](const Path &path, const LocalPath &dst) -> void { Get(dst, path); }));
+		AddCommand("get-id", "<id> get object by id",
+			make_function([this](mtp::u32 id) -> void { Get(mtp::ObjectId(id)); }));
+		AddCommand("get-id", "<id> <dst> get object by id to <dst>",
+                        make_function([this](mtp::u32 id, const LocalPath &dst) -> void { Get(dst, mtp::ObjectId(id)); }));
 
 		AddCommand("get-thumb", "<file> downloads thumbnail for file",
 			make_function([this](const Path &path) -> void { GetThumb(path); }));


### PR DESCRIPTION
The get-id allows me to fetch filtered content quickly after an lsext-r.

I fetch all content using aft-mtp-cli "lsext-r DCIM/Camera" 

(The samsung-phone has 8000 images in this dir, with no subdirectories, it takes 8 seconds or so.)

I filter out the images I have already downloaded and then I want to fetch the remaining 1000 images.

If I get each file with: 
aft-mtp-cli "get DCIM/Camera/20240606_144210.jpg" "get DCIM/Camera/20240607_121212.jpg" ...

then it scans the DCIM/Camera again to translate the file name into the id, and an extra 8 seconds is added on each get for a file that then only takes 200 ms to actually download.

If we add the "get-id" cli command, then I can do:
aft-mtp-cli "get-id 2360" "get-id 74622" ...
and I get the files immediately.

Forgive me if there is an existing way to do this without get-id. But I haven't found it yet.
