### PR TITLE
make CMAKE_OSX_DEPLOYMENT_TARGET a cache variable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,7 @@ message(STATUS "building for ${CMAKE_SYSTEM_NAME}")
 
 if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
 	set(USB_BACKEND_DARWIN TRUE)
-	set(CMAKE_OSX_DEPLOYMENT_TARGET 10.13)
+	set(CMAKE_OSX_DEPLOYMENT_TARGET 10.13 CACHE STRING "Minimum OS X deployment version")
 	find_program(OTOOL_BIN otool)
 endif()
 


### PR DESCRIPTION
Allow users to override the macOS deployment target via cmake command line or cache configuration.

Note: The following `-DCMAKE_OSX_DEPLOYMENT_TARGET=10.12` in workflow is ignored without this change.

https://github.com/whoozle/android-file-transfer-linux/blob/b1f89dc2499379fe09154660a2fec0a729a4c701/.github/workflows/actions.yml#L82

This also fix the following [error](https://hydra.nixos.org/build/324444025) on [nixpkgs](https://github.com/NixOS/nixpkgs/blob/master/pkgs/by-name/an/android-file-transfer/package.nix):

```
/nix/store/wjardn0gln6bm81nj5rvqbh62iwg2ybb-qtbase-6.10.2/lib/QtCore.framework/Headers/qfile.h:60:58: error: 'path' is unavailable: introduced in macOS 10.15
   60 | inline QString fromFilesystemPath(const std::filesystem::path &path)
```